### PR TITLE
Using babel-preset-latest

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
     "presets":[
-        "es2015", "react"
+        "latest", "react"
     ]
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "babel-core": "^6.24.1",
     "babel-loader": "^6.4.1",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-latest": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "html-webpack-plugin": "^2.28.0"
   }


### PR DESCRIPTION
Shifting from `babe-reset-es2015` to `babel-preset-latest` which includes support for `es2015` `es2016` and possibly `es2017`.

Which sounds kinda cool.

But also brings [more](https://github.com/tc39/proposals/blob/master/finished-proposals.md) on the table. #2 